### PR TITLE
Move values around to be closer to main

### DIFF
--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -85,7 +85,6 @@ WeaponData
 	"ammo_no_remove_from_stockpile"					"1"
 	"ammo_min_to_fire"								"1"
 
-
 	"reload_time" 									"1.85"
 	"reload_time_late1" 							"1.15"
 	"reloadempty_time"								"1.85"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -85,8 +85,6 @@ WeaponData
    "titanarmor_critical_hit_required"              "1"
 	"critical_hit"									"1"
 
-	MP_BASE
-	{
 		"ammo_default_total"							"40"
 		"ammo_stockpile_max"							"40"
 		"ammo_no_remove_from_stockpile"					"1"
@@ -118,7 +116,7 @@ WeaponData
 		"npc_damage_near_value_titanarmor"				"40"
 		"npc_damage_far_value_titanarmor" 				"0"
 
-		"enable_highlight_networking_on_creation"		"<KEEP_DEFAULT>"
+		"enable_highlight_networking_on_creation"		"1"
 
 		"damage_heavyarmor_nontitan_scale"				"0.35"
 
@@ -133,55 +131,9 @@ WeaponData
 		"spread_air_ads"  								"8.5"
 		"spread_wallrunning"  							"8.5"
 		"spread_wallhanging"  							"8.5"
-	}
 
-	SP_BASE
-	{
-		"ammo_default_total"							"40"
-		"ammo_stockpile_max"							"64"
-		"ammo_no_remove_from_stockpile"					"0"
-		"ammo_min_to_fire"								"1"
 
-		"aimassist_adspull_weaponclass"					"broad_sp"
 
-		// Ammo
-		"ammo_clip_size"   								"8"
-
-		// Damage - When Used by Players
-		"damage_near_value"   							"100"
-		"damage_far_value"								"15"
-		"damage_near_value_titanarmor"					"200"
-		"damage_far_value_titanarmor" 					"20"
-		"damage_rodeo" 									"550"
-		"damage_near_distance"							"400"
-		"damage_far_distance" 							"1000"
-
-		"damage_headshot_scale"							"2"
-
-		"red_crosshair_range" 							"1000"
-
-		// Damage - When Used by NPCs
-		"npc_damage_near_value"   						"25"
-		"npc_damage_far_value"							"13"
-		"npc_damage_near_value_titanarmor"				"40"
-		"npc_damage_far_value_titanarmor" 				"0"
-
-		"enable_highlight_networking_on_creation"		"1"
-
-		"damage_heavyarmor_nontitan_scale"				"1"
-
-		// Spread
-		"spread_stand_hip"								"7"
-		"spread_stand_hip_run"							"7"
-		"spread_stand_hip_sprint"                       "7"
-		"spread_crouch_hip"   							"7"
-		"spread_air_hip"  								"7"
-		"spread_stand_ads"								"7"
-		"spread_crouch_ads"   							"7"
-		"spread_air_ads"  								"7"
-		"spread_wallrunning"  							"7"
-		"spread_wallhanging"  							"7"
-	}
 
 	// NPC
 	"proficiency_poor_spreadscale"					"7.0"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -17,7 +17,7 @@ WeaponData
 	"aimassist_adspull_weaponclass"					"broad"
 	"minimap_reveal_distance"						"32000"
 	"fast_swap_to"									"0"
-	"leveled_pickup"								"1"
+	"leveled_pickup"								"0"
 
 	// Models
 	"viewmodel"   									"models/weapons/shotgun_doublebarrel/ptpov_shotgun_doublebarrel.mdl"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -19,8 +19,18 @@ WeaponData
 	"fast_swap_to"									"0"
 	"leveled_pickup"								"1"
 
+	// Models
+	"viewmodel"   									"models/weapons/shotgun_doublebarrel/ptpov_shotgun_doublebarrel.mdl"
+	"playermodel" 									"models/weapons/shotgun_doublebarrel/w_shotgun_doublebarrel.mdl"
+
 	"OnWeaponPrimaryAttack"							"OnWeaponPrimaryAttack_weapon_shotgun"
 	"OnWeaponNpcPrimaryAttack"						"OnWeaponNpcPrimaryAttack_weapon_shotgun"
+
+	"viewmodel_offset_ads"							"0 0 0"
+	"dof_zoom_nearDepthStart"						"2.000"
+	"dof_zoom_nearDepthEnd"							"4.750"
+	"dof_nearDepthStart"							"3.683"
+	"dof_nearDepthEnd"								"5.300"
 
 	// Menu
 	"menu_category"                                 "shotgun"
@@ -29,10 +39,6 @@ WeaponData
 	"stat_range"  									"70"
 	"stat_accuracy"   								"65"
 	"stat_rof"										"30"
-
-	// Models
-	"viewmodel"   									"models/weapons/shotgun_doublebarrel/ptpov_shotgun_doublebarrel.mdl"
-	"playermodel" 									"models/weapons/shotgun_doublebarrel/w_shotgun_doublebarrel.mdl"
 
 	// Effects
 	"tracer_effect"   								"weapon_tracers_shotgun"
@@ -195,12 +201,6 @@ WeaponData
 	"npc_max_burst"									"1"
 	"npc_rest_time_between_bursts_min"				"0.5"
 	"npc_rest_time_between_bursts_max"				"0.7"
-
-	"viewmodel_offset_ads"							"0 0 0"
-	"dof_zoom_nearDepthStart"						"2.000"
-	"dof_zoom_nearDepthEnd"							"4.750"
-	"dof_nearDepthStart"							"3.683"
-	"dof_nearDepthEnd"								"5.300"
 
 	// Behavior
 	"fire_rate"   									"2.75"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -5,7 +5,6 @@ WeaponData
 	"shortprintname"								"#WPN_SHOTGUN_DBLBARREL_SHORT"
 	"description" 									"#WPN_SHOTGUN_DBLBARREL_DESC"
 	"longdesc"										"#WPN_SHOTGUN_DBLBARREL_LONGDESC"
-
 	"menu_icon"										"rui/weapon_icons/mp_weapon_shotgun_doublebarrel"
 	"hud_icon"										"rui/weapon_icons/mp_weapon_shotgun_doublebarrel"
 	"viewmodel_offset_hip" 							"2 -2 -2"
@@ -95,7 +94,7 @@ WeaponData
 
 		"aimassist_adspull_weaponclass"					"broad"
 
-	// Ammo
+		// Ammo
 		"ammo_clip_size"   								"2"
 
 		// Damage - When Used by Players
@@ -211,10 +210,10 @@ WeaponData
 	"reload_time_late1" 							"1.15"
 	"reloadempty_time"								"1.85"
 	"reloadempty_time_late1"						"1.15"
-	"holster_time"									"0.5"  
-	"deploy_time" 									"0.66" 
+	"holster_time"									"0.5"
+	"deploy_time" 									"0.66"
 	"lower_time"  									"0.25"
-	"raise_time"  									"0.3"  
+	"raise_time"  									"0.3"
 	"vortex_refire_behavior"  						"bullet"
 	"allow_empty_fire"								"0"
 	"reload_enabled"  								"1"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -106,7 +106,7 @@ WeaponData
 	"vortex_absorb_effect"							"wpn_vortex_projectile_shotgun_FP"
 	"vortex_absorb_effect_third_person"				"wpn_vortex_projectile_shotgun"
 	"vortex_absorb_sound"							"Vortex_Shield_AbsorbBulletSmall"
-	"vortex_absorb_sound_1P_VS_3P"					"Vortex_Shield_AbsorbBulletSmall_1P_VS_3P"
+	"vortex_absorb_sound_1p_vs_3p"					"Vortex_Shield_AbsorbBulletSmall_1P_VS_3P"
 	"projectile_adjust_to_gun_barrel"				"1"
 
 	"sound_dryfire"									"shotgun_dryfire"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -26,6 +26,7 @@ WeaponData
 	"OnWeaponPrimaryAttack"							"OnWeaponPrimaryAttack_weapon_shotgun"
 	"OnWeaponNpcPrimaryAttack"						"OnWeaponNpcPrimaryAttack_weapon_shotgun"
 
+
 	"viewmodel_offset_ads"							"0 0 0"
 	"dof_zoom_nearDepthStart"						"2.000"
 	"dof_zoom_nearDepthEnd"							"4.750"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -11,7 +11,7 @@ WeaponData
 	"weaponClass" 									"human"
 	"weaponSubClass"								"shotgun"
 	"body_type"										"light"
-	"fire_mode"   									"auto"
+	"fire_mode"   									"semi-auto"
 	"pickup_hold_prompt"  							"Hold [USE] [WEAPONNAME]"
 	"pickup_press_prompt" 							"[USE] [WEAPONNAME]"
 	"minimap_reveal_distance"						"32000"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -274,7 +274,6 @@ WeaponData
 	"viewmodel_shake_right"							"0.0"
 
 	// Bob
-	// Bob
 	"bob_cycle_time"  								"0.45"
 	"bob_vert_dist"   								"0.1"
 	"bob_horz_dist"   								"0.1"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -40,6 +40,18 @@ WeaponData
 	"stat_accuracy"   								"65"
 	"stat_rof"										"30"
 
+		// Spread
+	"spread_stand_hip"								"8.5"
+	"spread_stand_hip_run"							"8.5"
+	"spread_stand_hip_sprint"                       "8.5"
+	"spread_crouch_hip"   							"8.5"
+	"spread_air_hip"  								"8.5"
+	"spread_stand_ads"								"8.5"
+	"spread_crouch_ads"   							"8.5"
+	"spread_air_ads"  								"8.5"
+	"spread_wallrunning"  							"8.5"
+	"spread_wallhanging"  							"8.5"
+
 	// Effects
 	"tracer_effect"   								"weapon_tracers_shotgun"
 	"impact_effect_table" 							"inc_bullet"
@@ -119,18 +131,6 @@ WeaponData
 		"enable_highlight_networking_on_creation"		"1"
 
 		"damage_heavyarmor_nontitan_scale"				"0.35"
-
-		// Spread
-		"spread_stand_hip"								"8.5"
-		"spread_stand_hip_run"							"8.5"
-		"spread_stand_hip_sprint"                       "8.5"
-		"spread_crouch_hip"   							"8.5"
-		"spread_air_hip"  								"8.5"
-		"spread_stand_ads"								"8.5"
-		"spread_crouch_ads"   							"8.5"
-		"spread_air_ads"  								"8.5"
-		"spread_wallrunning"  							"8.5"
-		"spread_wallhanging"  							"8.5"
 
 
 

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -1,10 +1,10 @@
 WeaponData
 {
 	// General
-	"printname"   									"2R"
-	"shortprintname"								"2R"
-	"description" 									"Double Barrel Shotgun"
-	"longdesc"										"Double Barrel Shotgun"
+	"printname"   									"#WPN_SHOTGUN_DBLBARREL"
+	"shortprintname"								"#WPN_SHOTGUN_DBLBARREL_SHORT"
+	"description" 									"#WPN_SHOTGUN_DBLBARREL_DESC"
+	"longdesc"										"#WPN_SHOTGUN_DBLBARREL_LONGDESC"
 
 	"menu_icon"										"rui/weapon_icons/mp_weapon_shotgun_doublebarrel"
 	"hud_icon"										"rui/weapon_icons/mp_weapon_shotgun_doublebarrel"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -86,6 +86,10 @@ WeaponData
 	"ammo_min_to_fire"								"1"
 
 
+	"reload_time" 									"1.85"
+	"reload_time_late1" 							"1.15"
+	"reloadempty_time"								"1.85"
+	"reloadempty_time_late1"						"1.15"
 
 
 	// Effects
@@ -158,10 +162,6 @@ WeaponData
 	"zoom_time_in"									"0.25"
 	"zoom_time_out"   								"0.2"
 	"zoom_fov"										"55"
-	"reload_time" 									"1.85"
-	"reload_time_late1" 							"1.15"
-	"reloadempty_time"								"1.85"
-	"reloadempty_time_late1"						"1.15"
 	"holster_time"									"0.5"
 	"deploy_time" 									"0.66"
 	"lower_time"  									"0.25"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -52,6 +52,32 @@ WeaponData
 	"spread_wallrunning"  							"8.5"
 	"spread_wallhanging"  							"8.5"
 
+		// Damage - When Used by Players
+	"damage_near_distance"							"300"
+	"damage_far_distance" 							"700"
+	"damage_near_value"   							"220"
+	"damage_far_value"								"25"
+	"damage_falloff_type"							"inverse"
+	"damage_inverse_distance"						"130"
+	"damage_near_value_titanarmor"					"130"
+	"damage_far_value_titanarmor" 					"10"
+	"damage_rodeo" 									"700"
+
+		"damage_headshot_scale"							"1.25"
+
+		"red_crosshair_range" 							"750"
+
+		// Damage - When Used by NPCs
+		"npc_damage_near_value"   						"25"
+		"npc_damage_far_value"							"13"
+		"npc_damage_near_value_titanarmor"				"40"
+		"npc_damage_far_value_titanarmor" 				"0"
+
+		"enable_highlight_networking_on_creation"		"1"
+
+		"damage_heavyarmor_nontitan_scale"				"0.35"
+
+
 	// Effects
 	"tracer_effect"   								"weapon_tracers_shotgun"
 	"impact_effect_table" 							"inc_bullet"
@@ -106,32 +132,6 @@ WeaponData
 
 		// Ammo
 		"ammo_clip_size"   								"2"
-
-		// Damage - When Used by Players
-	"damage_near_distance"							"300"
-	"damage_far_distance" 							"700"
-	"damage_near_value"   							"220"
-	"damage_far_value"								"25"
-	"damage_falloff_type"							"inverse"
-	"damage_inverse_distance"						"130"
-	"damage_near_value_titanarmor"					"130"
-	"damage_far_value_titanarmor" 					"10"
-	"damage_rodeo" 									"700"
-
-		"damage_headshot_scale"							"1.25"
-
-		"red_crosshair_range" 							"750"
-
-		// Damage - When Used by NPCs
-		"npc_damage_near_value"   						"25"
-		"npc_damage_far_value"							"13"
-		"npc_damage_near_value_titanarmor"				"40"
-		"npc_damage_far_value_titanarmor" 				"0"
-
-		"enable_highlight_networking_on_creation"		"1"
-
-		"damage_heavyarmor_nontitan_scale"				"0.35"
-
 
 
 

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -40,6 +40,10 @@ WeaponData
 	"stat_accuracy"   								"65"
 	"stat_rof"										"30"
 
+	"impulse_force"   								"800"
+
+	"impact_effect_table" 							"inc_bullet"
+
 		// Spread
 	"spread_stand_hip"								"8.5"
 	"spread_stand_hip_run"							"8.5"
@@ -98,7 +102,6 @@ WeaponData
 
 	// Effects
 	"tracer_effect"   								"weapon_tracers_shotgun"
-	"impact_effect_table" 							"inc_bullet"
 	"vortex_absorb_effect"							"wpn_vortex_projectile_shotgun_FP"
 	"vortex_absorb_effect_third_person"				"wpn_vortex_projectile_shotgun"
 	"vortex_absorb_sound"							"Vortex_Shield_AbsorbBulletSmall"
@@ -126,9 +129,9 @@ WeaponData
 	"fx_muzzle_flash_attach"						"muzzle_flash"
 
 
-	"impulse_force"   								"800"
 
 	"critical_hit_damage_scale"						"1"
+	"critical_hit"									"1"
 
 	dof_zoom_focusArea_horizontal					0.036
 	dof_zoom_focusArea_top							0.070
@@ -136,7 +139,6 @@ WeaponData
 
 
    "titanarmor_critical_hit_required"              "1"
-	"critical_hit"									"1"
 
 
 	// Behavior

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -16,7 +16,6 @@ WeaponData
 	"pickup_press_prompt" 							"[USE] [WEAPONNAME]"
 	"aimassist_adspull_weaponclass"					"broad"
 	"minimap_reveal_distance"						"32000"
-	"fast_swap_to"									"0"
 	"leveled_pickup"								"0"
 
 	// Models

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -139,24 +139,6 @@ WeaponData
 	"critical_hit"									"1"
 
 
-	// NPC
-	"proficiency_poor_spreadscale"					"7.0"
-	"proficiency_average_spreadscale" 				"5.0"
-	"proficiency_good_spreadscale"					"4.5"
-	"proficiency_very_good_spreadscale"   			"3.7"
-
-	"npc_min_engage_range"							"0"
-	"npc_max_engage_range"							"800"
-	"npc_min_engage_range_heavy_armor"				"500"
-	"npc_max_engage_range_heavy_armor"				"800"
-	"npc_min_range"   								"0"
-	"npc_max_range"   								"800"
-
-	"npc_min_burst"									"1"
-	"npc_max_burst"									"1"
-	"npc_rest_time_between_bursts_min"				"0.5"
-	"npc_rest_time_between_bursts_max"				"0.7"
-
 	// Behavior
 	"fire_rate"   									"2.75"
 	"zoom_time_in"									"0.25"
@@ -312,6 +294,24 @@ WeaponData
 	"sway_max_pitch_zoomed"  						"0.03"
 	"sway_turn_up_rotate_pitch_zoomed"				"0.07"
 	"sway_turn_down_rotate_pitch_zoomed"			"-0.07"
+
+	// NPC
+	"proficiency_poor_spreadscale"					"7.0"
+	"proficiency_average_spreadscale" 				"5.0"
+	"proficiency_good_spreadscale"					"4.5"
+	"proficiency_very_good_spreadscale"   			"3.7"
+
+	"npc_min_engage_range"							"0"
+	"npc_max_engage_range"							"800"
+	"npc_min_engage_range_heavy_armor"				"500"
+	"npc_max_engage_range_heavy_armor"				"800"
+	"npc_min_range"   								"0"
+	"npc_max_range"   								"800"
+
+	"npc_min_burst"									"1"
+	"npc_max_burst"									"1"
+	"npc_rest_time_between_bursts_min"				"0.5"
+	"npc_rest_time_between_bursts_max"				"0.7"
 
 	// WeaponED Unhandled Key/Values and custom script Key/Values
 	"bob_tilt_angle"  								"0.5"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -14,6 +14,7 @@ WeaponData
 	"fire_mode"   									"semi-auto"
 	"pickup_hold_prompt"  							"Hold [USE] [WEAPONNAME]"
 	"pickup_press_prompt" 							"[USE] [WEAPONNAME]"
+	"aimassist_adspull_weaponclass"					"broad"
 	"minimap_reveal_distance"						"32000"
 	"fast_swap_to"									"0"
 	"leveled_pickup"								"1"
@@ -90,7 +91,6 @@ WeaponData
 		"ammo_no_remove_from_stockpile"					"1"
 		"ammo_min_to_fire"								"1"
 
-		"aimassist_adspull_weaponclass"					"broad"
 
 		// Ammo
 		"ammo_clip_size"   								"2"

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -53,15 +53,20 @@ WeaponData
 	"spread_wallhanging"  							"8.5"
 
 		// Damage - When Used by Players
+	"damage_type" 									"bullet"
 	"damage_near_distance"							"300"
 	"damage_far_distance" 							"700"
 	"damage_near_value"   							"220"
 	"damage_far_value"								"25"
-	"damage_falloff_type"							"inverse"
-	"damage_inverse_distance"						"130"
 	"damage_near_value_titanarmor"					"130"
 	"damage_far_value_titanarmor" 					"10"
+
 	"damage_rodeo" 									"700"
+	"damage_falloff_type"							"inverse"
+	"damage_inverse_distance"						"130"
+	"damage_falloff_type"							"inverse"
+	"damage_inverse_distance"						"100"
+	"damage_flags"									"DF_SHOTGUN | DF_BULLET | DF_KNOCK_BACK | DF_DISMEMBERMENT"
 
 		"damage_headshot_scale"							"1.25"
 
@@ -120,10 +125,6 @@ WeaponData
 	"fx_muzzle_flash_world"							"mflash_shotgun_FULL"
 	"fx_muzzle_flash_attach"						"muzzle_flash"
 
-	"damage_type" 									"bullet"
-	"damage_falloff_type"							"inverse"
-	"damage_inverse_distance"						"100"
-	"damage_flags"									"DF_SHOTGUN | DF_BULLET | DF_KNOCK_BACK | DF_DISMEMBERMENT"
 
 	"impulse_force"   								"800"
 

--- a/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
+++ b/Northstar.Custom/mod/scripts/weapons/mp_weapon_shotgun_doublebarrel.txt
@@ -78,6 +78,16 @@ WeaponData
 		"damage_heavyarmor_nontitan_scale"				"0.35"
 
 
+		// Ammo
+	"ammo_stockpile_max"							"40"
+	"ammo_default_total"							"40"
+	"ammo_clip_size"   								"2"
+	"ammo_no_remove_from_stockpile"					"1"
+	"ammo_min_to_fire"								"1"
+
+
+
+
 	// Effects
 	"tracer_effect"   								"weapon_tracers_shotgun"
 	"impact_effect_table" 							"inc_bullet"
@@ -123,16 +133,6 @@ WeaponData
 
    "titanarmor_critical_hit_required"              "1"
 	"critical_hit"									"1"
-
-		"ammo_default_total"							"40"
-		"ammo_stockpile_max"							"40"
-		"ammo_no_remove_from_stockpile"					"1"
-		"ammo_min_to_fire"								"1"
-
-
-		// Ammo
-		"ammo_clip_size"   								"2"
-
 
 
 	// NPC


### PR DESCRIPTION
Moves keys around so that it's closer to the original file which in turn makes it easier to compare changes in the diff in https://github.com/R2Northstar/NorthstarMods/pull/660 as well as making it easier to diff stuff in the future using `git blame`.

Also fixes the fire rate back to `semi-auto` (was accidentally changed to `auto` while copying values from EVA8).